### PR TITLE
Moved query to onStart to fix bug

### DIFF
--- a/app/src/main/java/com/example/vybe/MyVibesActivity.java
+++ b/app/src/main/java/com/example/vybe/MyVibesActivity.java
@@ -178,46 +178,6 @@ public class MyVibesActivity extends AppCompatActivity {
         myVibesAdapter = new MyVibesAdapter(this, R.layout.my_vibe_item, vibeEventList);
         vibesListView.setAdapter(myVibesAdapter);
 
-        CollectionReference collectionReference = db.collection(vibeEventDBPath);
-        Query query = collectionReference.orderBy("datetime", Query.Direction.DESCENDING);
-
-        query.addSnapshotListener(this, new EventListener<QuerySnapshot>() {
-            @Override
-            public void onEvent(@Nullable QuerySnapshot queryDocumentSnapshots, @Nullable FirebaseFirestoreException e) {
-                // TODO: Stub out with other query above
-                vibeEventList.clear();
-                for (QueryDocumentSnapshot doc : queryDocumentSnapshots) {
-//                    LocalDateTime ldt = LocalDateTime.ofInstant(Instant.ofEpochMilli(doc.getDate("datetime").getTime()),
-//                            TimeZone.getDefault().toZoneId());
-                    LocalDateTime ldt = doc.getDate("datetime").toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime();
-                    Log.d(TAG, ldt.toString());
-                    /*
-                    String reason = (String) doc.getData().get("reason");
-                    String socSit = (String) doc.getData().get("socSit");
-                    String id = (String) doc.getData().get("ID");
-                    String vibe = (String) doc.getData().get("vibe");
-                    String image = (String) doc.getData().get("image");
-                    double latitude = (double) doc.getData().get("latitude");
-                    double longitude = (double) doc.getData().get("longitude");
-                    vibeEventList.add(new VibeEvent(vibe, ldt, reason, socSit, id, image, latitude, longitude));
-                     */
-                    VibeEvent vibeEvent = new VibeEvent();
-                    vibeEvent.setReason(doc.getString("reason"));
-                    vibeEvent.setSocialSituation(doc.getString("socSit"));
-                    vibeEvent.setId(doc.getId());
-                    vibeEvent.setVibe(doc.getString("vibe"));
-                    if (doc.getData().get("image") != null) {
-                        vibeEvent.setImage(doc.getString("image"));
-                    }
-                    if (doc.getData().get("latitude") != null && doc.getData().get("longitude") != null) {
-                        vibeEvent.setLatitude(doc.getDouble("latitude"));
-                        vibeEvent.setLongitude(doc.getDouble("longitude"));
-                    }
-                    vibeEventList.add(vibeEvent);
-                }
-                myVibesAdapter.notifyDataSetChanged();
-            }
-        });
 
         vibesListView.setOnItemClickListener((AdapterView<?> parent, View view, int position, long id) ->  {
             Intent viewVibe = new Intent(MyVibesActivity.this, ViewVibeActivity.class);
@@ -270,6 +230,48 @@ public class MyVibesActivity extends AppCompatActivity {
             public void onClick(View v) {
                 startActivity(new Intent(MyVibesActivity.this, SocialActivity.class));
             }
+        });
+    }
+
+    @Override
+    protected void onStart() {
+        super.onStart();
+        // Want to get the most recent list of mood history
+        CollectionReference collectionReference = db.collection(vibeEventDBPath);
+        Query query = collectionReference.orderBy("datetime", Query.Direction.DESCENDING);
+
+        query.get().addOnSuccessListener((QuerySnapshot queryDocumentSnapshots) -> {
+                vibeEventList.clear();
+                for (QueryDocumentSnapshot doc : queryDocumentSnapshots) {
+//                    LocalDateTime ldt = LocalDateTime.ofInstant(Instant.ofEpochMilli(doc.getDate("datetime").getTime()),
+//                            TimeZone.getDefault().toZoneId());
+                    LocalDateTime ldt = doc.getDate("datetime").toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime();
+                    Log.d(TAG, ldt.toString());
+                    /*
+                    String reason = (String) doc.getData().get("reason");
+                    String socSit = (String) doc.getData().get("socSit");
+                    String id = (String) doc.getData().get("ID");
+                    String vibe = (String) doc.getData().get("vibe");
+                    String image = (String) doc.getData().get("image");
+                    double latitude = (double) doc.getData().get("latitude");
+                    double longitude = (double) doc.getData().get("longitude");
+                    vibeEventList.add(new VibeEvent(vibe, ldt, reason, socSit, id, image, latitude, longitude));
+                     */
+                    VibeEvent vibeEvent = new VibeEvent();
+                    vibeEvent.setReason(doc.getString("reason"));
+                    vibeEvent.setSocialSituation(doc.getString("socSit"));
+                    vibeEvent.setId(doc.getId());
+                    vibeEvent.setVibe(doc.getString("vibe"));
+                    if (doc.getData().get("image") != null) {
+                        vibeEvent.setImage(doc.getString("image"));
+                    }
+                    if (doc.getData().get("latitude") != null && doc.getData().get("longitude") != null) {
+                        vibeEvent.setLatitude(doc.getDouble("latitude"));
+                        vibeEvent.setLongitude(doc.getDouble("longitude"));
+                    }
+                    vibeEventList.add(vibeEvent);
+                }
+                myVibesAdapter.notifyDataSetChanged();
         });
     }
 

--- a/app/src/main/java/com/example/vybe/MyVibesActivity.java
+++ b/app/src/main/java/com/example/vybe/MyVibesActivity.java
@@ -145,16 +145,7 @@ public class MyVibesActivity extends AppCompatActivity {
                                             vibeEvent.setLatitude(doc.getDouble("latitude"));
                                             vibeEvent.setLongitude(doc.getDouble("longitude"));
                                         }
-
-//                                            LocalDateTime ldt = doc.getDate("datetime").toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime();
-//                                            Log.d(TAG, ldt.toString());
-//                                            String reason = (String) doc.getData().get("reason");
-//                                            String socSit = (String) doc.getData().get("socSit");
-//                                            String id = (String) doc.getData().get("ID");
-//                                            String vibe = (String) doc.getData().get("vibe");
-//                                            String image = (String) doc.getData().get("image");
-//                                            double latitude = (double) doc.getData().get("latitude");
-//                                            double longitude = (double) doc.getData().get("longitude");
+                                        
                                         if (allFlag) {
                                             vibeEventList.add(vibeEvent);
                                         } else {

--- a/app/src/main/java/com/example/vybe/MyVibesActivity.java
+++ b/app/src/main/java/com/example/vybe/MyVibesActivity.java
@@ -145,7 +145,7 @@ public class MyVibesActivity extends AppCompatActivity {
                                             vibeEvent.setLatitude(doc.getDouble("latitude"));
                                             vibeEvent.setLongitude(doc.getDouble("longitude"));
                                         }
-                                        
+
                                         if (allFlag) {
                                             vibeEventList.add(vibeEvent);
                                         } else {
@@ -234,20 +234,8 @@ public class MyVibesActivity extends AppCompatActivity {
         query.get().addOnSuccessListener((QuerySnapshot queryDocumentSnapshots) -> {
                 vibeEventList.clear();
                 for (QueryDocumentSnapshot doc : queryDocumentSnapshots) {
-//                    LocalDateTime ldt = LocalDateTime.ofInstant(Instant.ofEpochMilli(doc.getDate("datetime").getTime()),
-//                            TimeZone.getDefault().toZoneId());
                     LocalDateTime ldt = doc.getDate("datetime").toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime();
                     Log.d(TAG, ldt.toString());
-                    /*
-                    String reason = (String) doc.getData().get("reason");
-                    String socSit = (String) doc.getData().get("socSit");
-                    String id = (String) doc.getData().get("ID");
-                    String vibe = (String) doc.getData().get("vibe");
-                    String image = (String) doc.getData().get("image");
-                    double latitude = (double) doc.getData().get("latitude");
-                    double longitude = (double) doc.getData().get("longitude");
-                    vibeEventList.add(new VibeEvent(vibe, ldt, reason, socSit, id, image, latitude, longitude));
-                     */
                     VibeEvent vibeEvent = new VibeEvent();
                     vibeEvent.setReason(doc.getString("reason"));
                     vibeEvent.setSocialSituation(doc.getString("socSit"));


### PR DESCRIPTION
[//]: # (These are comments and are used for reference and will not show up in the PR)

Description: 

ListView was not calling the query after returning from AddEditVibeActivity because of the Activity lifecycle. I moved it onto onStart() so that the query is always called instead of only once in onCreate

[//]: # (Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change)

[//]: # (automatically closes given issue number)
Closes #142   

Proof of Concept

[//]: # (Attach Image of feature added or fix applied and working)
[//]: # (Please provide images of tests passing)

Checklist

[//]: # (Add an x between square brackets to mark item as done)

- [x] Follows style guidelines and is **properly commented**
- [x] Code changes generate no new warnings