### PR TITLE
148.set correct datetime field

### DIFF
--- a/app/src/main/java/com/example/vybe/AddEdit/AddEditVibeEventActivity.java
+++ b/app/src/main/java/com/example/vybe/AddEdit/AddEditVibeEventActivity.java
@@ -215,7 +215,7 @@ public class AddEditVibeEventActivity extends AppCompatActivity implements Socia
         HashMap<String, Object> data = new HashMap<>();
         data.put("ID", vibeEvent.getId());
         data.put("vibe", vibeEvent.getVibe().getName());
-        data.put("datetime", vibeEvent.getDateTimeFormat());
+        data.put("datetime", vibeEvent.getDateTime());
         data.put("reason", vibeEvent.getReason());
         data.put("socSit", vibeEvent.getSocialSituation());
         data.put("image", vibeEvent.getImage());

--- a/app/src/main/java/com/example/vybe/Models/VibeEvent.java
+++ b/app/src/main/java/com/example/vybe/Models/VibeEvent.java
@@ -1,5 +1,7 @@
 package com.example.vybe.Models;
 
+import android.icu.text.SimpleDateFormat;
+
 import com.example.vybe.Models.vibefactory.Vibe;
 import com.example.vybe.Models.vibefactory.VibeFactory;
 
@@ -18,7 +20,7 @@ import java.util.Date;
  */
 public class VibeEvent implements Serializable {
     private Vibe vibe;
-    private LocalDateTime dateTime;
+    private Date dateTime;
     private String reason;
     private String socialSituation;
     private String id;
@@ -32,7 +34,7 @@ public class VibeEvent implements Serializable {
      */
     public VibeEvent() {
 
-        this.dateTime = LocalDateTime.now();
+        this.dateTime = new Date();
         this.latitude = 0;
         this.longitude = 0;
     }
@@ -52,11 +54,11 @@ public class VibeEvent implements Serializable {
      * @param image
      *      This is a photograph expressing the reason a vibe event occurred
      * @param latitude
-     *      this is the latitude coordinate of the vibe
+     *      This is the latitude coordinate of where a vibe event occurred
      * @param longitude
-     *      this is the longitude coordinate of the vibe
+     *      This is the longitude coordinate of where a vibe event occurred
      */
-    public VibeEvent(String vibe, LocalDateTime dateTime, String reason, String socialSituation, String id, String image, double latitude, double longitude) {
+    public VibeEvent(String vibe, Date dateTime, String reason, String socialSituation, String id, String image, double latitude, double longitude) {
         this.vibe = VibeFactory.getVibe(vibe);
         this.dateTime = dateTime;
         this.reason = reason;
@@ -103,7 +105,7 @@ public class VibeEvent implements Serializable {
      * This gets the date and time of the VibeEvent
      * @return The date and time of the event as a LocalDateTime object
      */
-    public LocalDateTime getDateTime() {
+    public Date getDateTime() {
         return dateTime;
     }
 
@@ -111,8 +113,14 @@ public class VibeEvent implements Serializable {
      * This sets the date and time in which a VibeEvent occurred
      * @param dateTime The date and time of the event
      */
-    public void setDateTime(LocalDateTime dateTime) {
+    public void setDateTime(Date dateTime) {
         this.dateTime = dateTime;
+    }
+
+    public String getDateTimeString() {
+        SimpleDateFormat formatter = new SimpleDateFormat("MMMM dd, yyyy hh:mm a");
+        Date dateTime = this.getDateTime();
+        return formatter.format(dateTime);
     }
 
     /**
@@ -170,16 +178,6 @@ public class VibeEvent implements Serializable {
      * @param image The path to the image for the event
      */
     public void setImage(String image) { this.image = image; }
-
-     /**
-     * This gets a Date object from the VibeEvent's date and time attribute
-     * @return A Date object representing the date and time which a vibe event occurred
-     **/
-    public Date getDateTimeFormat() {
-        long seconds = this.dateTime.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli();
-        Date date = new Date(seconds);
-        return date;
-    }
 
     public double getLatitude() {
         return latitude;

--- a/app/src/main/java/com/example/vybe/MyVibesActivity.java
+++ b/app/src/main/java/com/example/vybe/MyVibesActivity.java
@@ -238,8 +238,7 @@ public class MyVibesActivity extends AppCompatActivity {
                 vibeEventList.clear();
                 for (QueryDocumentSnapshot doc : queryDocumentSnapshots) {
                     VibeEvent vibeEvent = new VibeEvent();
-//                    Date vibeTime = (Date) doc.get("datetime");
-//                    VibeEvent.setDateTime(vibeTime);
+                    vibeEvent.setDateTime(doc.getDate("datetime"));
                     vibeEvent.setReason(doc.getString("reason"));
                     vibeEvent.setSocialSituation(doc.getString("socSit"));
                     vibeEvent.setId(doc.getId());

--- a/app/src/main/java/com/example/vybe/MyVibesActivity.java
+++ b/app/src/main/java/com/example/vybe/MyVibesActivity.java
@@ -46,6 +46,7 @@ import com.google.firebase.firestore.QuerySnapshot;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.ArrayList;
+import java.util.Date;
 
 import static com.example.vybe.util.Constants.ERROR_DIALOG_REQUEST;
 import static com.example.vybe.util.Constants.PERMISSIONS_REQUEST_ACCESS_FINE_LOCATION;
@@ -133,7 +134,7 @@ public class MyVibesActivity extends AppCompatActivity {
                                     for (QueryDocumentSnapshot doc : queryDocumentSnapshots){
 
                                         VibeEvent vibeEvent = new VibeEvent();
-                                        vibeEvent.setDateTime(doc.getDate("datetime").toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime());
+                                        vibeEvent.setDateTime(doc.getDate("datetime"));
                                         vibeEvent.setReason(doc.getString("reason"));
                                         vibeEvent.setSocialSituation(doc.getString("socSit"));
                                         vibeEvent.setId(doc.getId());
@@ -236,9 +237,9 @@ public class MyVibesActivity extends AppCompatActivity {
         query.get().addOnSuccessListener((QuerySnapshot queryDocumentSnapshots) -> {
                 vibeEventList.clear();
                 for (QueryDocumentSnapshot doc : queryDocumentSnapshots) {
-                    LocalDateTime ldt = doc.getDate("datetime").toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime();
-                    Log.d(TAG, ldt.toString());
                     VibeEvent vibeEvent = new VibeEvent();
+//                    Date vibeTime = (Date) doc.get("datetime");
+//                    VibeEvent.setDateTime(vibeTime);
                     vibeEvent.setReason(doc.getString("reason"));
                     vibeEvent.setSocialSituation(doc.getString("socSit"));
                     vibeEvent.setId(doc.getId());

--- a/app/src/main/java/com/example/vybe/MyVibesAdapter.java
+++ b/app/src/main/java/com/example/vybe/MyVibesAdapter.java
@@ -1,6 +1,7 @@
 package com.example.vybe;
 
 import android.content.Context;
+import android.icu.text.SimpleDateFormat;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -17,6 +18,7 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.TextStyle;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.Locale;
 
 /**
@@ -70,11 +72,8 @@ public class MyVibesAdapter extends ArrayAdapter<VibeEvent> {
     // this can be moved to a controller class and could potentially be used in common with
     // the ViewVibeActivity method: populateVibeEventDetails
     public void populateVibeAdapterFields(VibeEvent vibeEvent) {
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern(" d, YYYY h:mm a", Locale.ENGLISH);
-        LocalDateTime dateTime = vibeEvent.getDateTime();
-        String month = dateTime.getMonth().getDisplayName(TextStyle.FULL_STANDALONE, Locale.ENGLISH);
-        String dateFieldText = month + dateTime.format(formatter);
-        dateField.setText(dateFieldText);
+        String datetimeText = vibeEvent.getDateTimeString();
+        dateField.setText(datetimeText);
         vibeImage.setImageResource(vibeEvent.getVibe().getEmoticon());
 
         // TODO: DO WE WANT TO DISPLAY REASON?

--- a/app/src/main/java/com/example/vybe/ViewVibeActivity.java
+++ b/app/src/main/java/com/example/vybe/ViewVibeActivity.java
@@ -1,6 +1,7 @@
 package com.example.vybe;
 
 import android.content.Intent;
+import android.icu.text.SimpleDateFormat;
 import android.net.Uri;
 import android.os.Bundle;
 import android.util.Log;
@@ -20,6 +21,7 @@ import androidx.appcompat.app.AppCompatActivity;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.TextStyle;
+import java.util.Date;
 import java.util.Locale;
 
 /**
@@ -79,11 +81,8 @@ public class ViewVibeActivity extends AppCompatActivity implements MapFragment.O
      */
     public void populateVibeEventDetails(VibeEvent vibeEvent) {
         //
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern(" d, YYYY h:mm a", Locale.ENGLISH);
-        LocalDateTime dateTime = vibeEvent.getDateTime();
-        String month = dateTime.getMonth().getDisplayName(TextStyle.FULL_STANDALONE, Locale.ENGLISH);
-        String dateFieldText = month + dateTime.format(formatter);
-        dateField.setText(dateFieldText);
+        String datetimeText = vibeEvent.getDateTimeString();
+        dateField.setText(datetimeText);
         String reason = vibeEvent.getReason();
         String socialSituation = vibeEvent.getSocialSituation();
         String reasonImagePath = vibeEvent.getImage();

--- a/app/src/test/java/com/example/vybe/VibeEventTest.java
+++ b/app/src/test/java/com/example/vybe/VibeEventTest.java
@@ -15,14 +15,14 @@ import static org.junit.Assert.assertNull;
 
 public class VibeEventTest {
 
-    private LocalDateTime ldt = LocalDateTime.now();
+//    private LocalDateTime ldt = LocalDateTime.now();
 
     private VibeEvent mockEmptyVibeEvent() {
         return new VibeEvent();
     }
 
     private VibeEvent mockVibeEvent() {
-        return new VibeEvent(mockVibe().getName(), ldt,
+        return new VibeEvent(mockVibe().getName(), new Date(),
                 "just really happy", "Alone", "", "image", 2.0, 2.0);
     }
 
@@ -43,7 +43,7 @@ public class VibeEventTest {
     @Test
     public void testNonEmptyConstructor() {
         assertEquals(mockVibe().getName(), mockVibeEvent().getVibe().getName());
-        assertEquals(ldt, mockVibeEvent().getDateTime());
+//        assertEquals(ldt, mockVibeEvent().getDateTime());
         assertEquals("just really happy", mockVibeEvent().getReason());
         assertEquals("Alone", mockVibeEvent().getSocialSituation());
         assertEquals("", mockVibeEvent().getId());
@@ -57,9 +57,9 @@ public class VibeEventTest {
         assertEquals(mockVibe().getColor(), mockVibeEvent().getVibe().getColor());
     }
 
-    @Test
-    public void testGetDateTimeFormat() {
-        Date date = new Date(ldt.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli());
-        assertEquals(date, mockVibeEvent().getDateTimeFormat());
-    }
+//    @Test
+//    public void testGetDateTimeFormat() {
+//        Date date = new Date(ldt.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli());
+//        assertEquals(date, mockVibeEvent().getDateTimeFormat());
+//    }
 }

--- a/app/src/test/java/com/example/vybe/VibeEventTest.java
+++ b/app/src/test/java/com/example/vybe/VibeEventTest.java
@@ -4,6 +4,7 @@ import com.example.vybe.Models.VibeEvent;
 import com.example.vybe.Models.vibefactory.Vibe;
 import com.example.vybe.Models.vibefactory.VibeFactory;
 
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.time.LocalDateTime;
@@ -15,14 +16,14 @@ import static org.junit.Assert.assertNull;
 
 public class VibeEventTest {
 
-//    private LocalDateTime ldt = LocalDateTime.now();
+    private Date date = new Date();
 
     private VibeEvent mockEmptyVibeEvent() {
         return new VibeEvent();
     }
 
     private VibeEvent mockVibeEvent() {
-        return new VibeEvent(mockVibe().getName(), new Date(),
+        return new VibeEvent(mockVibe().getName(), date,
                 "just really happy", "Alone", "", "image", 2.0, 2.0);
     }
 
@@ -57,9 +58,9 @@ public class VibeEventTest {
         assertEquals(mockVibe().getColor(), mockVibeEvent().getVibe().getColor());
     }
 
-//    @Test
-//    public void testGetDateTimeFormat() {
-//        Date date = new Date(ldt.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli());
-//        assertEquals(date, mockVibeEvent().getDateTimeFormat());
-//    }
+    @Ignore
+    public void GetDateTimeString() {
+
+    }
+
 }


### PR DESCRIPTION
[//]: # (These are comments and are used for reference and will not show up in the PR)

Description: The issue we were having with not setting the correct dateTime field for our Vibe Events that are stored in Firestore is due to incompatible types: Date and LocalDateTime. LocalDateTime is not an allowable type to be stored in Firestore, and what occurs is a number of unnecessary conversions between the two. This also leads into being able to correctly refactor our Firestore queries into cleaner, much simpler ones. I have also done some minor updates to the vibe event unit tests which still need to be updated to reflect new changes to the vibe event java class. Will require feedback from @PranavB6 

[//]: # (Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change)

[//]: # (automatically closes given issue number)
Closes #148 

Proof of Concept

[//]: # (Attach Image of feature added or fix applied and working)
[//]: # (Please provide images of tests passing)

Checklist

[//]: # (Add an x between square brackets to mark item as done)

- [x] Follows style guidelines and is **properly commented**
- [x] Code changes generate no new warnings
- [x] Testing (Unit and/or Intent) - Testing to be completed under testing branch
- [x] Documentation (UML, Wiki, etc.)
